### PR TITLE
2 propagation issues in GraphQL

### DIFF
--- a/examples/graphql/client.js
+++ b/examples/graphql/client.js
@@ -13,6 +13,7 @@ query {
       address {
         country
       }
+      description
     }
   }
 }

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -40,6 +40,7 @@
     "@opentelemetry/node": "^0.23.0",
     "@opentelemetry/tracing": "^0.23.0",
     "apollo-server": "^2.18.1",
+    "apollo-server-express": "^2.18.1",
     "express": "^4.17.1",
     "express-graphql": "^0.11.0",
     "graphql": "^15.3.0"

--- a/examples/graphql/schema.js
+++ b/examples/graphql/schema.js
@@ -9,6 +9,7 @@ const url1 = 'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/
 function getData(url) {
   return new Promise((resolve, reject) => {
     // [ISSUE 2] Baggage not getting propagated through Apollo GraphQL resolvers.
+    // This works for express-graphql, but for not Apollo.
     console.log('getdata baggage', otel.propagation.getBaggage(otel.context.active()));
     https.get(url, (response) => {
       let data = '';

--- a/examples/graphql/schema.js
+++ b/examples/graphql/schema.js
@@ -2,11 +2,14 @@
 
 const https = require('https');
 const graphql = require('graphql');
+const otel = require('@opentelemetry/api');
 
 const url1 = 'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/package.json';
 
 function getData(url) {
   return new Promise((resolve, reject) => {
+    // [ISSUE 2] Baggage not getting propagated through Apollo GraphQL resolvers.
+    console.log('getdata baggage', otel.propagation.getBaggage(otel.context.active()));
     https.get(url, (response) => {
       let data = '';
       response.on('data', (chunk) => {
@@ -61,12 +64,12 @@ function getAuthor(id) {
 
 function prepareData() {
   addAuthor('John', 'Poland', 'Szczecin');
-  addAuthor('Alice', 'Poland', 'Warsaw');
-  addAuthor('Bob', 'England', 'London');
-  addAuthor('Christine', 'France', 'Paris');
+  //addAuthor('Alice', 'Poland', 'Warsaw');
+  //addAuthor('Bob', 'England', 'London');
+  //addAuthor('Christine', 'France', 'Paris');
   addBook('First Book', [0, 1]);
-  addBook('Second Book', [2]);
-  addBook('Third Book', [3]);
+  //addBook('Second Book', [2]);
+  //addBook('Third Book', [3]);
 }
 
 prepareData();

--- a/examples/graphql/server-apollo.js
+++ b/examples/graphql/server-apollo.js
@@ -2,20 +2,42 @@
 
 require('./tracer');
 
-const { ApolloServer } = require('apollo-server');
+const express = require('express');
+const { ApolloServer } = require('apollo-server-express');
 const buildSchema = require('./schema');
+const otel = require('@opentelemetry/api');
 
 // Construct a schema, using GraphQL schema language
 const schema = buildSchema();
 
 const server = new ApolloServer({ schema });
-server.listen().then(({ url }) => {
-  console.log(`🚀  Server ready at ${url}`);
-});
 
-// app.use('/graphql', server);
-// app.listen(4000);
+const testMw = function (req, res, next) {
+  otel.context.with(
+    otel.propagation.setBaggage(
+      otel.context.active(),
+      otel.propagation.createBaggage({
+        'test': { value: 'testValue' },
+      })
+    ),
+    () => {
+      console.log('attached baggage', otel.propagation.getBaggage(otel.context.active()));
+      otel.context.bind(otel.context.active(), next());
+    }
+  );
+}
 
-// server.applyMiddleware({ app });
+const printMw = function (req, res, next) {
+  console.log('printMw baggage', otel.propagation.getBaggage(otel.context.active()));
+  next();
+}
 
-console.log('Running a GraphQL API server at http://localhost:4000/graphql');
+const app = express();
+app.use(testMw);
+app.use(printMw);
+
+const gmw = server.getMiddleware({path: '/graphql'})
+app.use(gmw);
+app.listen(4000);
+
+console.log('Running a GraphQL Apollo API server at http://localhost:4000/graphql');

--- a/examples/graphql/server-express.js
+++ b/examples/graphql/server-express.js
@@ -5,10 +5,33 @@ require('./tracer');
 const express = require('express');
 const { graphqlHTTP } = require('express-graphql');
 const buildSchema = require('./schema');
+const otel = require('@opentelemetry/api');
 
 const schema = buildSchema();
 
+const testMw = function (req, res, next) {
+  otel.context.with(
+    otel.propagation.setBaggage(
+      otel.context.active(),
+      otel.propagation.createBaggage({
+        'test': { value: 'testValue' },
+      })
+    ),
+    () => {
+      console.log('attached baggage', otel.propagation.getBaggage(otel.context.active()));
+      otel.context.bind(otel.context.active(), next());
+    }
+  );
+}
+
+const printMw = function (req, res, next) {
+  console.log('printMw baggage', otel.propagation.getBaggage(otel.context.active()));
+  next();
+}
+
 const app = express();
+app.use(testMw);
+app.use(printMw);
 app.use('/graphql', graphqlHTTP({
   schema,
   graphiql: true,

--- a/examples/graphql/tracer.js
+++ b/examples/graphql/tracer.js
@@ -25,7 +25,8 @@ registerInstrumentations({
       // depth: 2,
       // mergeItems: true,
     }),
-    new HttpInstrumentation(),
+    // [ISSUE 1] Propagation through express middleware DOES NOT work if HttpInstrumentation is present!
+    // new HttpInstrumentation(),
     new ExpressInstrumentation(),
   ],
 });


### PR DESCRIPTION
This example repros 2 propagation issues with Node GraphQL.

### Issue 1:
The injection of baggage in the express middleware does not get propagated to the subsequent middleware with the presence of HttpInstrumentation(). Note: This works if HttpInstrumentation() is removed.

Steps to repro:
1. Run express server in one terminal `npm run server:express`
2. Run client in another terminal `npm run client`
3. Observe in the server logs that the printMw does not get the baggage injected in the testMw.

Expected:
```
attached baggage BaggageImpl { _entries: Map { 'test' => { value: 'testValue' } } }
printMw baggage undefined
```
Observed:
```
attached baggage BaggageImpl { _entries: Map { 'test' => { value: 'testValue' } } }
printMw baggage BaggageImpl { _entries: Map { 'test' => { value: 'testValue' } } }
```

### Issue 2:
Baggage injected in the express middleware does not get propagated to Apollo GraphQL resolvers (apollo-server-express).

Steps to repro:
1. Run Apollo server in one terminal `npm run server:apollo`
2. Run client in another terminal `npm run client`
3. Observe in the server logs that the `getdata baggage` printed appears undefined.

Expected:
```
getdata baggage BaggageImpl { _entries: Map { 'test' => { value: 'testValue' } } }
```
Observed:
```
getdata baggage undefined
```
